### PR TITLE
fix missing timeout in clients

### DIFF
--- a/client.go
+++ b/client.go
@@ -114,8 +114,10 @@ func NewClient(options Options) *Client {
 	}
 
 	// add timeout to clients
-	httpclient.Timeout = options.Timeout
-	httpclient2.Timeout = options.Timeout
+	if options.Timeout > 0 {
+		httpclient.Timeout = options.Timeout
+		httpclient2.Timeout = options.Timeout
+	}
 
 	// if necessary adjusts per-request timeout proportionally to general timeout (30%)
 	if options.Timeout > time.Second*15 && options.RetryMax > 1 && !options.NoAdjustTimeout {

--- a/client.go
+++ b/client.go
@@ -111,6 +111,10 @@ func NewClient(options Options) *Client {
 		backoff = options.Backoff
 	}
 
+	// add timeout to clients
+	httpclient.Timeout = options.Timeout
+	httpclient2.Timeout = options.Timeout
+
 	// if necessary adjusts per-request timeout proportionally to general timeout (30%)
 	if options.Timeout > time.Second*15 && options.RetryMax > 1 && !options.NoAdjustTimeout {
 		httpclient.Timeout = time.Duration(options.Timeout.Seconds()*0.3) * time.Second

--- a/client.go
+++ b/client.go
@@ -65,23 +65,25 @@ type Options struct {
 // DefaultOptionsSpraying contains the default options for host spraying
 // scenarios where lots of requests need to be sent to different hosts.
 var DefaultOptionsSpraying = Options{
-	RetryWaitMin:  1 * time.Second,
-	RetryWaitMax:  30 * time.Second,
-	Timeout:       30 * time.Second,
-	RetryMax:      5,
-	RespReadLimit: 4096,
-	KillIdleConn:  true,
+	RetryWaitMin:    1 * time.Second,
+	RetryWaitMax:    30 * time.Second,
+	Timeout:         30 * time.Second,
+	RetryMax:        5,
+	RespReadLimit:   4096,
+	KillIdleConn:    true,
+	NoAdjustTimeout: true,
 }
 
 // DefaultOptionsSingle contains the default options for host bruteforce
 // scenarios where lots of requests need to be sent to a single host.
 var DefaultOptionsSingle = Options{
-	RetryWaitMin:  1 * time.Second,
-	RetryWaitMax:  30 * time.Second,
-	Timeout:       30 * time.Second,
-	RetryMax:      5,
-	RespReadLimit: 4096,
-	KillIdleConn:  false,
+	RetryWaitMin:    1 * time.Second,
+	RetryWaitMax:    30 * time.Second,
+	Timeout:         30 * time.Second,
+	RetryMax:        5,
+	RespReadLimit:   4096,
+	KillIdleConn:    false,
+	NoAdjustTimeout: true,
 }
 
 // NewClient creates a new Client with default settings.


### PR DESCRIPTION
# Proposed Changes

- currently `.Timeout` is used with `context.withTimeout` and context is only called/wait at end of each retry loop . 
so If target is slow client does not exit until start of next iteration 
- adding timeout to httpclient fixes this


closes #41 