### PR TITLE
removes .Prepare() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,8 @@ scanme.sh/with/path?some'param=`'+OR+ORDER+BY+1--
 ```
 All above mentioned cases are handled internally in `retryablehttp`.
 
-
-### request with unsafe urls
- 
-`retryablehttp` allows creating requests with unsafe urls but requires some extra steps if `path` of url contains encoded characters (ex: `/%invalid/path`).
-
-- `Request.Prepare()` method should be called before request is executed and this applies a quick fix to avoid double url encoding (ex: `%e5` => `%25e5`)
-
-Note: this is a optional feature and only required if we want to allow unsafe urls. If `Request.Prepare()` is not called it follows the standard behaviour.
-
 ### Note
-It is not recommended to update `url.URL` instance of `Request` once a new request is created (ex `req.URL.Path = xyz`) due to internal logic or urls.
+It is not recommended to update `url.URL` instance of `Request` once a new request is created (ex `req.URL.Path = xyz`) due to internal logic of urls.
 In any case if it is not possible to follow above point due to some reason helper methods are available to reflect such changes
 
 - `Request.Update()` commits any changes made to query parameters (ex: `Request.URL.Query().Add(x,y)`)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/Mzack9999/go-http-digest-auth-client v0.6.1-0.20220414142836-eb8883508809
-	github.com/projectdiscovery/utils v0.0.7
+	github.com/projectdiscovery/utils v0.0.10-0.20230217185600-008d111dd1c1
 	golang.org/x/net v0.5.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,8 @@ github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl
 github.com/microcosm-cc/bluemonday v1.0.21 h1:dNH3e4PSyE4vNX+KlRGHT5KrSvjeUkoNPwEORjffHJg=
 github.com/microcosm-cc/bluemonday v1.0.21/go.mod h1:ytNkv4RrDrLJ2pqlsSI46O6IVXmZOBBD4SaJyDwwTkM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/projectdiscovery/utils v0.0.7 h1:jqDuZedy3t66o6ejQUXjgNWbyAHqiBqLAUDkst9DA2M=
-github.com/projectdiscovery/utils v0.0.7/go.mod h1:PCwA5YuCYWPgHaGiZmr53/SA9iGQmAnw7DSHuhr8VPQ=
-github.com/projectdiscovery/utils v0.0.8-0.20230206142604-469c07cf5050 h1:PwtYD40LMJag5jpB3F2bi1y4tLAMUPIeuWO37txfbOI=
-github.com/projectdiscovery/utils v0.0.8-0.20230206142604-469c07cf5050/go.mod h1:PCwA5YuCYWPgHaGiZmr53/SA9iGQmAnw7DSHuhr8VPQ=
+github.com/projectdiscovery/utils v0.0.10-0.20230217185600-008d111dd1c1 h1:ZxRylh56CH9MwmhrF4sLenwqpmhu+Gxwl3o4x+wlTVY=
+github.com/projectdiscovery/utils v0.0.10-0.20230217185600-008d111dd1c1/go.mod h1:dZqlayNwgCGn2HgYfKrI71RjBEyKsEPovrU+UDfpQWw=
 github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca h1:NugYot0LIVPxTvN8n+Kvkn6TrbMyxQiuvKdEwFdR9vI=
 github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca/go.mod h1:uugorj2VCxiV1x+LzaIdVa9b4S4qGAcH6cbhh4qVxOU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=

--- a/request.go
+++ b/request.go
@@ -107,18 +107,6 @@ func (r *Request) Update() {
 	updateScheme(r.URL.URL)
 }
 
-// Prepares request (applies hot patch if any. Ex: Path Unescape to prevent double url encoding)
-// calling multiple times may have unexpected results unlike Update() method
-func (r *Request) Prepare() {
-	// hot patch to avoid url path encoding issues
-	// by default we decode encoded/escaped path and internally http.Request encodes them again
-	// this avoid double url encoding (or reencoding or path)
-	if rawPath, err := url.QueryUnescape(r.URL.Path); err == nil {
-		r.URL.Path = rawPath
-	}
-	r.Update()
-}
-
 // SetURL updates request url (i.e http.Request.URL) with given url
 func (r *Request) SetURL(u *urlutil.URL) {
 	r.URL = u

--- a/request_test.go
+++ b/request_test.go
@@ -54,7 +54,6 @@ func TestEncodedPaths(t *testing.T) {
 			t.Fatalf("got %v with payload %v", err.Error(), v)
 		}
 
-		req.Prepare()
 		bin, err := req.Dump()
 		if err != nil {
 			t.Errorf("failed to dump request body for payload %v got %v", v, err)


### PR DESCRIPTION
# Proposed Changes
- `.Prepare()` method is no longer needed due to refactor in `urlutils`
   - code refactor in `urlutils` seperated logic and functions of `relative paths` and `full urls` which was caused. behind double url encoding issue



- closes #57 