### PR TITLE
Set effective content-length for dump

### DIFF
--- a/request.go
+++ b/request.go
@@ -150,6 +150,8 @@ func (r *Request) Dump() ([]byte, error) {
 		clone.ContentLength = 0
 		clone.Body = nil
 		delete(clone.Header, "Content-length")
+	} else {
+		clone.ContentLength = resplen
 	}
 	dumpBytes, err := httputil.DumpRequestOut(clone.Request, dumpbody)
 	if err != nil {


### PR DESCRIPTION
Closes https://github.com/projectdiscovery/nuclei/pull/3947

Note: Dumped body with Chunked Transfer Encoding is totally legitimate and this change is only aesthetic, therefore we need to ensure that this change doesn't alter any internal mechanism. In general no alteration should be made to the request whatsoever.