### PR TITLE
Fix data race caused by concurrent access to the request URL during scans

### DIFF
--- a/request.go
+++ b/request.go
@@ -123,7 +123,7 @@ func (r *Request) SetURL(u *urlutil.URL) {
 // Clones and returns new Request
 func (r *Request) Clone(ctx context.Context) *Request {
 	r.Update()
-	ux := r.URL.Clone()
+	ux := r.URL
 	req := r.Request.Clone(ctx)
 	req.URL = ux.URL
 	ux.Update()

--- a/request.go
+++ b/request.go
@@ -105,13 +105,17 @@ func (r *Request) BodyBytes() ([]byte, error) {
 
 // Update request URL with new changes of parameters if any
 func (r *Request) Update() {
+	// Make a copy of the URL to avoid data races
+	r.URL = r.URL.Clone()
 	r.URL.Update()
+	r.Request.URL = r.URL.URL
 	updateScheme(r.URL.URL)
 }
 
 // SetURL updates request url (i.e http.Request.URL) with given url
 func (r *Request) SetURL(u *urlutil.URL) {
-	r.URL = u
+	// Make a copy of the URL to avoid data races
+	r.URL = u.Clone()
 	r.Request.URL = u.URL
 	r.Update()
 }


### PR DESCRIPTION
A data race was identified when the Nuclei engine calls `request.dump()` when the `net/http` client transport for the request is still active (as part of a scan goroutine). This PR changes the `Update()` function to clone and replace the URL, avoiding the race. This can be tricky to reproduce (might require a HTTP/2 target) and unfortunately I misplaced the original data race log that led to this fix, but it hasn't popped up again since I made this change.