### PR TITLE
fix: close idle conns for `HTTPClient2`

### DIFF
--- a/do.go
+++ b/do.go
@@ -151,6 +151,7 @@ func (c *Client) closeIdleConnections() {
 		} else {
 			c.requestCounter.Store(0)
 			c.HTTPClient.CloseIdleConnections()
+			c.HTTPClient2.CloseIdleConnections()
 		}
 	}
 }


### PR DESCRIPTION
fix: close idle conns for `HTTPClient2` to prevent memory leak

The HTTPClient2 instance was being created on every `NewClient()` call but its idle connections were never closed, leading to memory  accumulation.
While HTTPClient2 is only used as a fallback for HTTP/2 protocol errors, it still allocates ~45MB of per client instance (24MB for the client + 21MB for HTTP/2 transport config).

This commit make sure that when `KillIdleConn` is enabled, both `HTTPClient` and `HTTPClient2` have their idle connections properly closed, preventing the memory leak in scenarios where multiple client instances are created.

Fixes #482.