### PR TITLE
fix: populate `GetBody` to support 307/308 redirects

### DIFF
--- a/default_client_test.go
+++ b/default_client_test.go
@@ -30,7 +30,7 @@ func TestConnectionReuse(t *testing.T) {
 
 	router := httprouter.New()
 	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		fmt.Fprintf(w, "this is a test")
+		_, _ = fmt.Fprintf(w, "this is a test")
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -55,7 +55,7 @@ func TestConnectionReuse(t *testing.T) {
 				resp, err := client.Do(req)
 				require.Nil(t, err)
 				_, _ = io.Copy(io.Discard, resp.Body)
-				resp.Body.Close()
+				_ = resp.Body.Close()
 			}
 		}()
 	}

--- a/do.go
+++ b/do.go
@@ -127,7 +127,7 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 	// By default, we close the response body and return an error without
 	// returning the response
 	if resp != nil {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 	c.closeIdleConnections()
 	return nil, fmt.Errorf("%s %s giving up after %d attempts: %w", req.Method, req.URL, retryMax+1, err)
@@ -139,7 +139,7 @@ func (c *Client) drainBody(req *Request, resp *http.Response) {
 	if err != nil {
 		req.Metrics.DrainErrors++
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 }
 
 const closeConnectionsCounter = 100
@@ -248,5 +248,5 @@ func (c *Client) wrapContextWithTrace(req *Request) {
 	}
 	req.TraceInfo = traceInfo
 
-	req.Request = req.Request.WithContext(httptrace.WithClientTrace(req.Request.Context(), trace))
+	req.Request = req.Request.WithContext(httptrace.WithClientTrace(req.Context(), trace))
 }

--- a/request.go
+++ b/request.go
@@ -93,7 +93,7 @@ func (r *Request) WithContext(ctx context.Context) *Request {
 // This function is not thread-safe; do not call it at the same time as another
 // call, or at the same time this request is being used with Client.Do.
 func (r *Request) BodyBytes() ([]byte, error) {
-	if r.Request.Body == nil {
+	if r.Body == nil {
 		return nil, nil
 	}
 	buf := new(bytes.Buffer)

--- a/request_test.go
+++ b/request_test.go
@@ -98,7 +98,7 @@ func TestRedirectPOSTWithBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("client.Do failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -135,7 +135,7 @@ func TestRedirectPOSTWithBodyFromRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("client.Do failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -158,7 +158,7 @@ func setupRedirectServer(t *testing.T, expectedBody string) *httptest.Server {
 		if err != nil {
 			t.Logf("redirect read body err: %v", err)
 		}
-		r.Body.Close()
+		_ = r.Body.Close()
 
 		w.Header().Set("Location", "/target")
 		w.WriteHeader(http.StatusTemporaryRedirect) // 307
@@ -170,24 +170,24 @@ func setupRedirectServer(t *testing.T, expectedBody string) *httptest.Server {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		r.Body.Close()
+		_ = r.Body.Close()
 
 		if len(body) == 0 {
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte("empty body"))
+			_, _ = w.Write([]byte("empty body"))
 
 			return
 		}
 
 		if string(body) != expectedBody {
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte("body mismatch"))
+			_, _ = w.Write([]byte("body mismatch"))
 
 			return
 		}
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("success"))
+		_, _ = w.Write([]byte("success"))
 	})
 
 	return httptest.NewServer(mux)

--- a/util.go
+++ b/util.go
@@ -19,7 +19,7 @@ func Discard(req *Request, resp *http.Response, RespReadLimit int64) {
 	if err != nil {
 		req.Metrics.DrainErrors++
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 }
 
 // getLength returns length of a Reader efficiently


### PR DESCRIPTION
### Description

When sending POST requests with a non-empty body
that trigger 307/308 redirects, the redirects fail
because the underlying `http.Request.GetBody` is
nil by default.

This patch populates `GetBody` using the existing
reusable body reader, allowing the `net/http`
client to rewind and replay the body.

Fixes #493.

### Proof

patch:

```console
$ go test -v -race -run "^TestRedirectPOST" .
=== RUN   TestRedirectPOSTWithBody
--- PASS: TestRedirectPOSTWithBody (0.00s)
=== RUN   TestRedirectPOSTWithBodyFromRequest
--- PASS: TestRedirectPOSTWithBodyFromRequest (0.00s)
PASS
ok  	github.com/projectdiscovery/retryablehttp-go	1.052s
```

main:

```console
$ git cherry-pick e49953b
[main 9b73fba] test: adds `TestRedirectPOST*` tests
 Date: Sat Dec 6 00:04:02 2025 +0700
 1 file changed, 124 insertions(+)
$ go test -v -race -run "^TestRedirectPOST" .
=== RUN   TestRedirectPOSTWithBody
    request_test.go:105: Expected status 200, got 307. Body: 
--- FAIL: TestRedirectPOSTWithBody (0.00s)
=== RUN   TestRedirectPOSTWithBodyFromRequest
--- PASS: TestRedirectPOSTWithBodyFromRequest (0.00s)
FAIL
FAIL	github.com/projectdiscovery/retryablehttp-go	0.052s
FAIL
```