### PR TITLE
Fix panic in FullJitterBackoff on the first retry

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -86,8 +86,16 @@ func FullJitterBackoff() func(min, max time.Duration, attemptNum int, resp *http
 	return func(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
 		duration := attemptNum * 1000000000 << 1
 
+		// On the first retry attemptNum is 0, so duration-attemptNum is 0 and
+		// rand.Intn would panic ("invalid argument to Intn"). Clamp the span to
+		// at least 1 so the jitter is always drawn from a valid range.
+		span := duration - attemptNum
+		if span < 1 {
+			span = 1
+		}
+
 		randMutex.Lock()
-		jitter := rand.Intn(duration-attemptNum) + int(min)
+		jitter := rand.Intn(span) + int(min)
 		randMutex.Unlock()
 
 		if jitter > int(max) {

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -1,0 +1,22 @@
+package retryablehttp
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFullJitterBackoffFirstRetryNoPanic(t *testing.T) {
+	backoff := FullJitterBackoff()
+	min := 100 * time.Millisecond
+	max := 5 * time.Second
+
+	for _, attemptNum := range []int{0, 1, 2, 5, 10} {
+		wait := backoff(min, max, attemptNum, nil)
+		if wait < 0 {
+			t.Fatalf("attemptNum=%d: negative backoff duration %v", attemptNum, wait)
+		}
+		if wait > max {
+			t.Fatalf("attemptNum=%d: backoff %v exceeds max %v", attemptNum, wait, max)
+		}
+	}
+}


### PR DESCRIPTION
Hi, I work on supply-chain / open-source security and was reading through the backoff strategies while evaluating this client.

FullJitterBackoff panics on the very first retry. The retry loop in do.go calls the backoff with attemptNum starting at 0 (`for i := 0; ...`, then `c.Backoff(..., i, resp)`). With attemptNum == 0, `duration := attemptNum * 1000000000 << 1` is 0, so `duration - attemptNum` is 0 and `rand.Intn(0)` panics with "invalid argument to Intn". Any client wired up with `client.Backoff = retryablehttp.FullJitterBackoff()` crashes the first time it needs to back off, which happens on a normal recoverable error or 5xx, no unusual input required.

The other three strategies (DefaultBackoff, LinearJitterBackoff, ExponentialJitterBackoff) all handle attemptNum 0 fine, so this one is the odd one out.

The change clamps the jitter span to at least 1 before calling rand.Intn, so attempt 0 draws from a valid range and returns min instead of panicking. Behavior for attemptNum >= 1 is unchanged.

I added a small test that runs FullJitterBackoff across attemptNum 0, 1, 2, 5, 10 and checks it does not panic and stays non-negative and within max. It panics before the fix and passes after. `go test ./...` and `go vet` are green.

Happy to adjust if you would rather rework the algorithm more thoroughly.