### PR TITLE
Fix lint workflow for Go 1.25

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -10,16 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
-          
+          go-version-file: go.mod
+
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.12.2
           args: --timeout 5m
           working-directory: .


### PR DESCRIPTION
Bump golangci-lint to v2.12.2 (go1.25-built) via action@v9 and read the Go version from go.mod, so lint stops failing on the go1.24-vs-1.25.0 mismatch.